### PR TITLE
Removed incrementation from compute_intersections call

### DIFF
--- a/src/ghostfragment/fragmenting/intersections_by_recursion.cpp
+++ b/src/ghostfragment/fragmenting/intersections_by_recursion.cpp
@@ -45,7 +45,7 @@ void compute_intersection(const index_set& curr_frag, std::size_t starting_frag,
         // Add the intersection
         ints_so_far.insert(intersection);
 
-        compute_intersection(intersection, starting_frag + 1, frag_indices,
+        compute_intersection(intersection, starting_frag, frag_indices,
                              ints_so_far);
     }
 }

--- a/tests/cxx/unit_tests/ghostfragment/fragmenting/intersections_by_recursion.cpp
+++ b/tests/cxx/unit_tests/ghostfragment/fragmenting/intersections_by_recursion.cpp
@@ -217,7 +217,7 @@ TEST_CASE("Bug associated with #62") {
     // truncated at order (n-1) for a system with n monomers, e.g., a three-body
     // expansion on water tetramer would exhibit this bug. This regression test
     // ensures that the module works for a three-body truncation of water 4
-    // (n.b. we just use hydrogens for each atom as the module only cares about
+    // (n.b. we just use hydrogen atoms as the module only cares about
     // nuclear indices).
 
     nuclei_type nuclei;


### PR DESCRIPTION
There are two different increments that occur within the function, removing the increment within the final function call of the loop removes the n-plus-1 issue with the n body expansion.

Commenting out the `++starting_frag;` line causes the program to stall, while removing the `+ 1` does not.